### PR TITLE
Nufpar

### DIFF
--- a/code/nucore/nucoretypes.h
+++ b/code/nucore/nucoretypes.h
@@ -50,9 +50,9 @@ typedef struct
 
 typedef struct
 {
-	u32 x0_unk;
-	void (*x4_unk_cb)(FPar*);
-} unkFParStruct;
+	char* str;
+	void (*cb)(FPar*);
+} FParCommand;
 
 typedef struct
 {
@@ -66,7 +66,8 @@ typedef struct
 	s32 bufferPos;
 	s32 bufferEndPos;
 	u32 f7;
-	unkFParStruct* commandStack[8]; // The last entry is the index of the last entry, where -1 is null.
+	s32 commandStack[7]; // The last entry is the index of the last entry, where -1 is null.
+	FParCommand* fpCmd;
 	u32 fileLength;
 } FPar;
 

--- a/code/nucore/nucoretypes.h
+++ b/code/nucore/nucoretypes.h
@@ -50,6 +50,12 @@ typedef struct
 
 typedef struct
 {
+	u32 x0_unk;
+	void (*x4_unk_cb)(FPar*);
+} unkFParStruct;
+
+typedef struct
+{
 	fileHandle handle;
 	u8 buffer[0x1000];
 	char textBuffer[0x100];
@@ -60,7 +66,7 @@ typedef struct
 	s32 bufferPos;
 	s32 bufferEndPos;
 	u32 f7;
-	s32 commandStack[8]; // The last entry is the index of the last entry, where -1 is null.
+	unkFParStruct* commandStack[8]; // The last entry is the index of the last entry, where -1 is null.
 	u32 fileLength;
 } FPar;
 

--- a/code/nucore/nufpar.c
+++ b/code/nucore/nufpar.c
@@ -1,6 +1,9 @@
 #include "nufpar.h"
 #include "nufile.h"
 
+#define LF 0xA;
+#define CR 0xD;
+
 u32 old_line_pos;
 
 char NuGetChar(FPar* fPar)
@@ -148,4 +151,54 @@ FPar* NuFParCreate(char* filename)
         NuFileClose(handle);
     }
     return NULL;
+}
+
+s32 NuFParGetLine(FPar* fPar) {
+    s32 i;
+    s32 var_r30_2;
+    char ch;
+    s8 temp_r3_2;
+    char* textBuffer_ptr;
+
+    i = 0;
+    fPar->linePos = 0;
+    
+    char inc_f2_flag = 1;
+    while ((ch = NuGetChar(fPar)) != 0) {
+        if(inc_f2_flag) {
+            fPar->f2 += 1;
+            inc_f2_flag = 0;
+        }
+        
+        if ((ch == CR) || (ch == LF)) {
+            if(ch == CR) {
+                ch = NuGetChar(fPar);
+            }
+            if (i == 0) {
+                inc_f2_flag = 1;
+            } else {
+                break;
+            }
+                
+        } else {
+            if (ch == 0x3B) {
+                if (i == 0) {
+                    do {
+                        ch = NuGetChar(fPar);
+                    } while(!((ch == LF) || (ch == CR) || (ch == 0)));
+                    if(ch == CR) {
+                        ch = NuGetChar(fPar);
+                    }
+                    i = 0;
+                    fPar->linePos = 0;
+                    inc_f2_flag = 1;
+                    continue;
+                }
+            }
+            fPar->textBuffer[i] = ch;
+            i += 1;
+        }
+    }
+    fPar->textBuffer[i] = 0;
+    return i;
 }

--- a/code/nucore/nufpar.c
+++ b/code/nucore/nufpar.c
@@ -155,9 +155,7 @@ FPar* NuFParCreate(char* filename)
 
 s32 NuFParGetLine(FPar* fPar) {
     s32 i;
-    s32 var_r30_2;
     char ch;
-    s8 temp_r3_2;
     char* textBuffer_ptr;
 
     i = 0;
@@ -202,3 +200,61 @@ s32 NuFParGetLine(FPar* fPar) {
     fPar->textBuffer[i] = 0;
     return i;
 }
+
+
+/*
+// ppc2c output
+
+s32 gcc2_compiled__N132(s32, void*);
+
+? NuFParInterpretWord(void* arg0) {
+    s32 temp_r10;
+    s32 var_r30;
+    void* temp_r11;
+
+    //fileLength
+    temp_r10 = arg0->unk123C;
+    if (temp_r10 >= 0) {
+        temp_r11 = arg0 + 0x121C;
+        if ((s32) **(temp_r11 + (temp_r10 * 4)) != 0) {
+            var_r30 = 0;
+loop_3:
+            if (gcc2_compiled__N132(*(var_r30 + *(temp_r11 + (arg0->unk123C * 4))), arg0 + 0x1105) == 0) {
+                (var_r30 + *(temp_r11 + (arg0->unk123C * 4)))->unk4(arg0);
+                return 1;
+            }
+            var_r30 += 8;
+            if ((s32) *(var_r30 + *(temp_r11 + (arg0->unk123C * 4))) == 0) {
+                goto block_6;
+            }
+            goto loop_3;
+        }
+    }
+block_6:
+    return 0;
+}
+*/
+
+/*
+// I think commandStack might be an array of pointers to arrays of unkFParStruct? Refer to line 251 for comment
+ NuFParInterpretWord(FPar* fPar) {
+    s32 i;
+    if (fPar->fileLength >= 0) {
+        //if ((s32) **(temp_r11 + (fileLength * 4)) != 0) {
+		if ((fPar->commandStack[fPar->fileLength])[0].x0_unk != 0) {
+            i = 0;
+			do {
+				//if (gcc2_compiled__N132(*(var_r30 + *(commandStack + (fPar->fileLength * 4))), fPar + 0x1105) == 0) {
+				if (gcc2_compiled__N132((fPar->commandStack[fPar->fileLength])[0].x0_unk, fPar.wordBuffer+1) == 0) {
+					//(var_r30 + *(commandStack + (fPar->fileLength * 4)))->unk4(fPar);
+					// It seems like the second entry in the struct is a function pointer?
+					(fPar->commandStack[fPar->fileLength])[i].x4_unk_cb(fPar);
+					return 1;
+				}
+				i += 1;
+			} while(fPar->commandStack[fPar->fileLength])[i].x0_unk != 0);
+        }
+    }
+	return 0;
+}
+*/

--- a/code/nucore/nufpar.c
+++ b/code/nucore/nufpar.c
@@ -201,60 +201,17 @@ s32 NuFParGetLine(FPar* fPar) {
     return i;
 }
 
-
-/*
-// ppc2c output
-
-s32 gcc2_compiled__N132(s32, void*);
-
-? NuFParInterpretWord(void* arg0) {
-    s32 temp_r10;
-    s32 var_r30;
-    void* temp_r11;
-
-    //fileLength
-    temp_r10 = arg0->unk123C;
-    if (temp_r10 >= 0) {
-        temp_r11 = arg0 + 0x121C;
-        if ((s32) **(temp_r11 + (temp_r10 * 4)) != 0) {
-            var_r30 = 0;
-loop_3:
-            if (gcc2_compiled__N132(*(var_r30 + *(temp_r11 + (arg0->unk123C * 4))), arg0 + 0x1105) == 0) {
-                (var_r30 + *(temp_r11 + (arg0->unk123C * 4)))->unk4(arg0);
-                return 1;
-            }
-            var_r30 += 8;
-            if ((s32) *(var_r30 + *(temp_r11 + (arg0->unk123C * 4))) == 0) {
-                goto block_6;
-            }
-            goto loop_3;
-        }
-    }
-block_6:
-    return 0;
-}
-*/
-
-/*
-// I think commandStack might be an array of pointers to arrays of unkFParStruct? Refer to line 251 for comment
- NuFParInterpretWord(FPar* fPar) {
-    s32 i;
-    if (fPar->fileLength >= 0) {
-        //if ((s32) **(temp_r11 + (fileLength * 4)) != 0) {
-		if ((fPar->commandStack[fPar->fileLength])[0].x0_unk != 0) {
-            i = 0;
-			do {
-				//if (gcc2_compiled__N132(*(var_r30 + *(commandStack + (fPar->fileLength * 4))), fPar + 0x1105) == 0) {
-				if (gcc2_compiled__N132((fPar->commandStack[fPar->fileLength])[0].x0_unk, fPar.wordBuffer+1) == 0) {
-					//(var_r30 + *(commandStack + (fPar->fileLength * 4)))->unk4(fPar);
-					// It seems like the second entry in the struct is a function pointer?
-					(fPar->commandStack[fPar->fileLength])[i].x4_unk_cb(fPar);
-					return 1;
-				}
-				i += 1;
-			} while(fPar->commandStack[fPar->fileLength])[i].x0_unk != 0);
-        }
-    }
+// Something like this - I cannot fully confirmed this is 100% correct
+u8 NuFParInterpretWord(FPar* fPar) {
+	s32 i = 0;
+	if(fPar->fpCmd[0].str != NULL) {
+		do {
+			if (strcasecmp(fPar->fpCmd[i].str, fPar->wordBuffer + 1) != 0) {
+				fPar->fpCmd[i].cb(fPar);
+				return 1;
+			}
+			i += 1;
+		} while(fPar->fpCmd[i].str != NULL);
+	}
 	return 0;
 }
-*/


### PR DESCRIPTION
Pretty confident about NuFParGetLine (except maybe the return type).

NuFParInterpretWord, assuming it is also has FPar* as the argument type, is a bit confusing. The way it was using commandStack made it seem like commandStack is an array of pointers of a new struct that has two entries, 4 bytes for a u32 and 4 bytes for a function pointer - this is supported by ppc2c output, which increments a counter by 8 bytes, which makes sense when looping through 8-byte-sized structs. However, I am not super confident on my interpretation, but thought I would at least include the notes and C interpretation I had as a comment in nufpar.c.